### PR TITLE
Fix geojson-flatten require

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var geojsonNormalize = require('@mapbox/geojson-normalize'),
-    geojsonFlatten = require('geojson-flatten'),
+    geojsonFlatten = require('geojson-flatten').default,
     flatten = require('./flatten');
 
 module.exports = function(_) {


### PR DESCRIPTION
This resolves the conflict issue in the wemap/master patch, and allows us to ship a fix to mapbox-gl-draw asap without being blocked on the conflict: https://github.com/mapbox/geojson-coords/pull/2

@gpanneti you're still credited as the author of the fix