### PR TITLE
Fix geojsonFlatten not a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@ var geojsonNormalize = require('@mapbox/geojson-normalize'),
     geojsonFlatten = require('geojson-flatten'),
     flatten = require('./flatten');
 
+if (!(geojsonFlatten instanceof Function)) geojsonFlatten = geojsonFlatten.default;
+
 module.exports = function(_) {
     if (!_) return [];
     var normalized = geojsonFlatten(geojsonNormalize(_)),


### PR DESCRIPTION
Fixes import issue in a backwards-compatible way.

Closes #2 #8 

Credits for initial solution: @gpanneti #2 
CC: @ThisIsMissEm